### PR TITLE
deck.gl 8.6.8対応

### DIFF
--- a/gsi-terrain-loader/parse-terrain.js
+++ b/gsi-terrain-loader/parse-terrain.js
@@ -1,5 +1,5 @@
 import Martini from '@mapbox/martini';
-import { getMeshBoundingBox } from '@loaders.gl/loader-utils';
+import { getMeshBoundingBox } from '@loaders.gl/schema';
 
 function getTerrain(imageData, tileSize, elevationDecoder) {
     const { scaler, offset } = elevationDecoder;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     },
     "homepage": "https://github.com/Kanahiro/deckgl-gsi-terrain-layer#readme",
     "dependencies": {
-        "deck.gl": "^8.3.6"
+        "deck.gl": "^8.6.8"
     }
 }


### PR DESCRIPTION
細かく見れていませんが、最新のdeck.gl(8.6.8)で試したときに一部インポート元が変わっていたのでPRです。

