### PR TITLE
fix: support v8.9.x of deck.gl

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {TerrainLoader} from './gsi-terrain-loader/terrain-loader';
 import {TileLayer} from '@deck.gl/geo-layers';
-import {urlType, getURLFromTemplate} from  '@deck.gl/geo-layers/src/tile-layer/utils';
+import {urlType, getURLFromTemplate} from  '@deck.gl/geo-layers/src/tileset-2d';
 
 const DUMMY_DATA = [1];
 


### PR DESCRIPTION
Thank you for developing great library.
I fixed the code to support v8.9.x of decl.gl.